### PR TITLE
readme: fix remark about route id length

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -73,7 +73,7 @@ references it. Edit the file to enter the Miele device IPs and the same keys you
 created in Step 3.
 
 On all devices I have seen, the device route is identical to the device serial
-number zero padded on the left to form a 13-digit number, e.g. "0001234567891".
+number zero padded on the left to form a 12-digit number, e.g. "000123456789".
 
 Specify the device route as "auto" if you do not know. If "auto", the
 server will detect it upon startup, and print it in the log. You can update the


### PR DESCRIPTION
Route should be 12 characters, this lines up with the provided example configuration.
See: https://github.com/akappner/MieleRESTServer/blob/b99af8be4dd4fb598e8744bc4a0eeb86d6017dcc/examples/MieleRESTServer-example-config.yaml#L7C17-L7C29