### PR TITLE
README.md: Add G7360 to compatibility matrix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Users have reported the following devices to be compatible:
 Device Model | Device Type | Basic Info | Remote Start | DOP2
 -------------|-------------|------------|--------------|-----
 G3385	     | Dishwasher   |      X     |      ?       |  ?
+G7360        | Dishwasher   |      X     |      X       |  No
 G7364	     | Dishwasher   |      X     |      X       |  ?
 G7366	     | Dishwasher   |      X     |      X       |  No
 H7164        | Oven         |      X     |      ?       |  ?


### PR DESCRIPTION
Hi @akappner are you interested in additional information, besides the following information?

Miele device provisioning:

- Wi-Fi SSID: Miele@home-G7360-7
- DHCP service provided by Miele device: Yes
- via HTTP endpoints, only port 80 was available while provisioning the Miele device

Remote Start:

`{"DeviceReadyToStart": false, "DeviceRemoteStartCapable": true}`

DOP2:

`{"error": "DOP2 Root Node not found", "device": "192.168.10.209"}`