### PR TITLE
README.md: Add CM6360 to compatibility matrix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,20 +168,21 @@ Patches/pull requests welcome.
 
 Users have reported the following devices to be compatible:
 
-Device Model | Device Type | Basic Info | Remote Start | DOP2
--------------|-------------|------------|--------------|-----
-G3385	     | Dishwasher   |      X     |      ?       |  ?
-G7360        | Dishwasher   |      X     |      X       |  No
-G7364	     | Dishwasher   |      X     |      X       |  ?
-G7366	     | Dishwasher   |      X     |      X       |  No
-H7164        | Oven         |      X     |      ?       |  ?
-H7240BM	     | Oven / MW    |      X     |      ?       |  ?
-TWD360       | Dryer        |      X     |      ?       |  No
-WTD-160	     | Washer/Dryer |      X     |      X       |  No
-WWE460-WPS   | Washer       |      X     |      X       |  No
-WWF360-WPS   | Washer       |      X     |      ?       |  ?
-WWD660 WCS   | Washer       |      X     |      ?       |  ?
-WXF660 (W1)  | Washer       |      X     |      X       |  X
+| Device Model | Device Type  | Basic Info | Remote Start | DOP2 |
+|--------------|--------------|------------|--------------|------|
+| CM6360       | Coffee Maker | X          | ?            | No   |
+| G3385        | Dishwasher   | X          | ?            | ?    |
+| G7360        | Dishwasher   | X          | X            | No   |
+| G7364        | Dishwasher   | X          | X            | ?    |
+| G7366        | Dishwasher   | X          | X            | No   |
+| H7164        | Oven         | X          | ?            | ?    |
+| H7240BM      | Oven / MW    | X          | ?            | ?    |
+| TWD360       | Dryer        | X          | ?            | No   |
+| WTD-160      | Washer/Dryer | X          | X            | No   |
+| WWE460-WPS   | Washer       | X          | X            | No   |
+| WWF360-WPS   | Washer       | X          | ?            | ?    |
+| WWD660 WCS   | Washer       | X          | ?            | ?    |
+| WXF660 (W1)  | Washer       | X          | X            | X    |
 
 Additional reports appreciated.
 


### PR DESCRIPTION
Hi @akappner are you interested in additional information, besides the following information?

Miele device provisioning:

- Wi-Fi SSID: Miele@home-CM6360-17
- DHCP service provided by Miele device: Yes
- via HTTP endpoints, only port 80 was available while provisioning the Miele device

Remote Start:

`{"DeviceReadyToStart": false, "DeviceRemoteStartCapable": true}`

DOP2:

`{"error": "DOP2 Root Node not found", "device": "192.168.10.188"}`

I did not test "Remote Start" yet.