### PR TITLE
Add G7266 and WXR860 compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Users have reported the following devices to be compatible:
 |--------------|--------------|------------|--------------|------|
 | CM6360       | Coffee Maker | X          | ?            | No   |
 | G3385        | Dishwasher   | X          | ?            | ?    |
+| G7266        | Dishwasher   | X          | X            | No   |
 | G7360        | Dishwasher   | X          | X            | No   |
 | G7364        | Dishwasher   | X          | X            | ?    |
 | G7366        | Dishwasher   | X          | X            | No   |
@@ -197,6 +198,7 @@ Users have reported the following devices to be compatible:
 | WWF360-WPS   | Washer       | X          | ?            | ?    |
 | WWG760       | Washer       | X          | ?            | X    |
 | WXF660 (W1)  | Washer       | X          | X            | X    |
+| WXR860 WCS   | Washer       | X          | X            | No   |
 
 Additional reports appreciated.
 


### PR DESCRIPTION
Thank you for this project! Thrilled to report that Basic Info works for these two models.

`GET /walkdop2tree/<device>` returns `error: "DOP2 Root Node not found"` for both of these. I took that to mean there is no DOP2 support.

`GET /start/<device>` returns `{"DeviceReadyToStart": false, "DeviceRemoteStartCapable": true}`. So that looks good, but I haven't had a chance to test it yet.

It also looks like some Program IDs are not mapped for the WXR860. I'll try to gather a list and submit a PR.